### PR TITLE
BankTransfer added to FundingSourceType.cs

### DIFF
--- a/BarionClientLibrary/Operations/Enums/FundingSourceType.cs
+++ b/BarionClientLibrary/Operations/Enums/FundingSourceType.cs
@@ -4,6 +4,7 @@
     {
         All,
         Balance,
-        Bankcard
+        Bankcard,
+        BankTransfer
     }
 }


### PR DESCRIPTION
Please merge this minimalistic PR, as BankTransfer is a must for EUR payments.